### PR TITLE
use a string for the resource migration file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject appcanary/crustacean "0.1.3-SNAPSHOT"
+(defproject appcanary/crustacean "0.1.4-SNAPSHOT"
   :description "CRU operations & migrations for datomic"
   :url "http://example.com/FIXME"
   :license {:name "Apache License Version 2.0"

--- a/src/crustacean/migrations.clj
+++ b/src/crustacean/migrations.clj
@@ -86,7 +86,7 @@
 (defn get-migrations
   "Retrieve an entity's migrations"
   [entity]
-  (if-let [file (:migration-file entity)]
+  (if-let [file (-> entity :migration-file clojure.java.io/resource)]
     (read-string (slurp file))
     (throw (Exception. (str "Migration has no file:" (:name entity))))))
 
@@ -101,18 +101,18 @@
   (let [key-str (str (:name entity) "-" (.format (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss")
                                                    (.setTimeZone (java.util.TimeZone/getTimeZone "UTC")))
                                                  (java.util.Date.)))]
-    (if-let [file (:migration-file entity)]
-      (if (.exists (clojure.java.io/as-file file))
+    (if-let [file-path (:migration-file entity)]
+      (if-let [file (clojure.java.io/resource file-path)]
         (let [migrations (read-string (slurp file))
               last-entity (:entity (last migrations))]
           (spit file (pr-str (assoc migrations
                                     key-str
                                     {:entity (write-entity entity)
                                      :txes [(migration-txes last-entity entity)]}))))
-        (spit file (pr-str (ordered-map
-                            key-str
-                            {:entity (write-entity entity) :txes [(initial-txes entity)]}))))
-      (throw (Exception. (str "Migration has no file:" (:name entity)))))))
+        (spit (str "resources/" file-path) (pr-str (ordered-map
+                             key-str
+                             {:entity (write-entity entity) :txes [(initial-txes entity)]}))))
+      (throw (Exception. (str "Migration has no file asdf sadf sadf :" (:name entity)))))))
 
 ;; This is a macro so we can resolve the namespace
 (defn sync-entity

--- a/test/crustacean/t_core.clj
+++ b/test/crustacean/t_core.clj
@@ -10,10 +10,10 @@
             [crustacean.migrations :refer [write-migrations sync-entity]]))
 
 
-(def migration-file "resources/testdata/entity.edn")
+(def migration-file "testdata/entity.edn")
 ;; Create an entity to test with
 (defentity entity
-  (:migration-file "resources/testdata/entity.edn")
+  (:migration-file "testdata/entity.edn")
   (:fields [field1 :keyword :unique-value :assignment-required]
            [field2 :string :unique-identity :assignment-permitted]
            [field3 :boolean :indexed :assignment-permitted]
@@ -42,8 +42,8 @@
 (defn reset-db! []
   (do (d/delete-database db-url)
       (d/create-database db-url)
-      (when (.exists (clojure.java.io/as-file migration-file))
-        (clojure.java.io/delete-file migration-file))
+      (when (clojure.java.io/resource migration-file)
+        (clojure.java.io/delete-file (str "resources/" migration-file)))
       (write-migrations entity)
       (sync-entity (get-conn) entity)))
 

--- a/test/crustacean/t_migrations.clj
+++ b/test/crustacean/t_migrations.clj
@@ -30,20 +30,20 @@
   (get-migrations ..entity..) => ..migrations..
   (provided
     ..entity.. =contains=> {:migration-file ..somefile..}
-    (read-string (slurp ..somefile..)) => ..migrations..)
+    (clojure.java.io/resource ..somefile..) => ..some-resource..
+    (read-string (slurp ..some-resource..)) => ..migrations..)
 
   (get-migrations ..no-migrations-file..) => (throws Exception))
 
 (fact "`write-migrations` writes  migrations to a file"
-  (let [migration-file "resources/testdata/migrations.edn"
+  (let [migration-file "testdata/migrations.edn"
         entity {:migration-file migration-file}]
-    (when (.exists (clojure.java.io/as-file migration-file))
-      (clojure.java.io/delete-file migration-file)) ;; to get rid of emtpty file
+    (when (clojure.java.io/resource migration-file)
+      (clojure.java.io/delete-file (str "resources/" migration-file))) ;; to get rid of emtpty file
     (do (write-migrations entity) => nil
       (provided
         (initial-txes entity) => "migrations"))
-    (let [
-          [date {txes :txes}] (first (read-string (slurp migration-file)))]
+    (let [[date {txes :txes}] (first (read-string (slurp (clojure.java.io/resource migration-file))))]
       txes => ["migrations"])))
 
 (facts "about `sync-entity`"


### PR DESCRIPTION
we assume that the migration file in the entity is a string and we internally cast it to a resource
