### PR TITLE
Createdat

### DIFF
--- a/src/crustacean/core.clj
+++ b/src/crustacean/core.clj
@@ -268,7 +268,10 @@
                                 (fn [result [field-name func]]
                                   (assoc result (keyword field-name) func))
                                 ;; Start with the id field
-                                {:id (fnk [e] (:db/id e))}
+                                {:id (fnk [e] (:db/id e))
+                                 :_created-at (fnk [e] (let [tx (first (get e (keyword ns "_txCreated")))]
+                                                         {:id (:db/id tx)
+                                                          :instant (:db/txInstant tx)}))}
                                 computed-fields)]
 
      (reduce (fn [acc [field-name [field-type field-opts ref-model]]]

--- a/src/crustacean/core.clj
+++ b/src/crustacean/core.clj
@@ -269,7 +269,7 @@
                                   (assoc result (keyword field-name) func))
                                 ;; Start with the id field
                                 {:id (fnk [e] (:db/id e))
-                                 :_created-at (fnk [e] (let [tx (first (get e (keyword ns "_txCreated")))]
+                                 :created-at (fnk [e] (let [tx (first (get e (keyword ns "_txCreated")))]
                                                          {:id (:db/id tx)
                                                           :instant (:db/txInstant tx)}))}
                                 computed-fields)]

--- a/src/crustacean/migrations.clj
+++ b/src/crustacean/migrations.clj
@@ -144,7 +144,7 @@
 
   (let [migrations (cp/resources migration-dir)]
     (into {}
-          (for [[filename [uri]] migrations]
+          (for [[filename [uri]] migrations :when (re-matches #"^.*\.edn$" filename)]
             (let [[_ base-name] (re-matches #"/?(.*)\.edn" filename)  ;; Drop the starting / (if there) and the .edn extension
                   k (str (:name model) "-" base-name)]
               [k (read-string  (slurp uri))])))))


### PR DESCRIPTION
Right now we include a field

```
:_created-at {:id TRANSACTION-ID
         :instant DATE OF TRANSACTION}
```

With every entity

@phillmv I'd like your feedback on nomenclature here? Maybe it should be `:_created-tx` since it's a transaction not a timestamp?
