### PR TITLE
Sync schema after each transaction

### DIFF
--- a/src/crustacean/migrations.clj
+++ b/src/crustacean/migrations.clj
@@ -236,6 +236,8 @@
         sorted-migrations (sort-by #(.parse date-format (:date (second %))) all-migrations)]
     (doseq [[migration-name migration] sorted-migrations]
       ;; Make sure we sync schema up to every migration
+      ;; Occasionally, we have to wait for a given migration to conclude
+      ;; prior to running the next one.
       (when-let [db-after (:db-after (try (deref (c/ensure-conforms conn {migration-name migration}))
                                                   (catch Throwable e nil)))]
         (d/sync-schema conn (d/basis-t db-after))))))


### PR DESCRIPTION
This makes sure that we have the complete schema from the last one
before we start the next one
